### PR TITLE
Use registerTwigExtension()

### DIFF
--- a/src/EncodeEmail.php
+++ b/src/EncodeEmail.php
@@ -67,7 +67,7 @@ class EncodeEmail extends Plugin
         self::$plugin = $this;
 
         // Add in our Twig extensions
-        Craft::$app->view->twig->addExtension(new EncodeEmailTwigExtension());
+        Craft::$app->view->registerTwigExtension(new EncodeEmailTwigExtension());
 
         // Do something after we're installed
         Event::on(


### PR DESCRIPTION
Fixes a bug where the plugin may cause Twig to be loaded before it should be, and another bug where the extension might not be available if the Template Mode ever changes from CP to Site, or vise-versa.